### PR TITLE
Fix: Correct gradlew script for Linux environments

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Standard Gradle Wrapper script.
 # This script is responsible for downloading and running the correct Gradle version
@@ -17,11 +17,11 @@ if [ -z "$GRADLE_OPTS" ] && [ -z "$JAVA_OPTS" ]; then
 fi
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
-if $cygwin ; then
-    [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
-    [ -n "$GRADLE_HOME" ] && GRADLE_HOME=`cygpath --unix "$GRADLE_HOME"`
-    [ -n "$GRADLE_OPTS" ] && GRADLE_OPTS=`cygpath --unix "$GRADLE_OPTS"`
-fi
+#if $cygwin ; then
+#    [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+#    [ -n "$GRADLE_HOME" ] && GRADLE_HOME=`cygpath --unix "$GRADLE_HOME"`
+#    [ -n "$GRADLE_OPTS" ] && GRADLE_OPTS=`cygpath --unix "$GRADLE_OPTS"`
+#fi
 
 # Attempt to find JAVA_HOME if not set
 if [ -z "$JAVA_HOME" ] ; then


### PR DESCRIPTION
The root gradlew script was causing errors in your Linux-based CI environments (like GitHub Actions) due to two main issues:
1. `cygpath: not found`: The script contained a block for Cygwin environments that attempted to use `cygpath`, which is not available on Linux.
2. `Syntax error: Bad for loop variable`: The script used a C-style for loop `for ((...))` which is a bash extension, but the script's shebang was `#!/usr/bin/env sh`, potentially leading to execution by a more basic shell (like dash) that doesn't support this syntax.

This commit addresses these issues by:
- Changing the shebang to `#!/usr/bin/env bash` to ensure proper execution with bash.
- Commenting out the Cygwin-specific block, as it's not applicable and was causing errors in non-Cygwin environments.

These changes should allow the `./gradlew build` command (executed from the project root) to run without the previously reported script errors in your CI pipeline.