### PR TITLE
Fix: Update import statements in AppDatabase for new package name

### DIFF
--- a/app/src/main/java/com/example/mymaterialapp/db/AppDatabase.kt
+++ b/app/src/main/java/com/example/mymaterialapp/db/AppDatabase.kt
@@ -5,8 +5,8 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
-import com.example.mymaterialapp.model.LearningCard
-import com.example.mymaterialapp.model.LearningDeck
+import com.mostree.memorycard.model.LearningCard
+import com.mostree.memorycard.model.LearningDeck
 
 @Database(entities = [LearningDeck::class, LearningCard::class], version = 1, exportSchema = false)
 @TypeConverters(Converters::class)


### PR DESCRIPTION
I corrected the import statements for LearningDeck and LearningCard in AppDatabase.kt to reference com.mostree.memorycard.model instead of the old com.example.mymaterialapp.model.

This change is intended to resolve the 'cannot find symbol' error during the kaptDebugKotlin build task that occurred after partially refactoring the package name to com.mostree.memorycard.

The directory structure change for source files is still pending and needs to be done manually.