### PR TITLE
Refactor: Complete package name change to com.mostree.memorycard

### DIFF
--- a/app/src/main/java/com/mostree/memorycard/db/LearningCardDao.kt
+++ b/app/src/main/java/com/mostree/memorycard/db/LearningCardDao.kt
@@ -1,7 +1,7 @@
 package com.mostree.memorycard.db
 
 import androidx.room.*
-import com.example.mymaterialapp.model.LearningCard
+import com.mostree.memorycard.model.LearningCard
 import kotlinx.coroutines.flow.Flow
 
 @Dao

--- a/app/src/main/java/com/mostree/memorycard/db/LearningDeckDao.kt
+++ b/app/src/main/java/com/mostree/memorycard/db/LearningDeckDao.kt
@@ -1,7 +1,7 @@
-package com.example.mymaterialapp.db
+package com.mostree.memorycard.db
 
 import androidx.room.*
-import com.example.mymaterialapp.model.LearningDeck
+import com.mostree.memorycard.model.LearningDeck
 import kotlinx.coroutines.flow.Flow // For Flow-based observation
 
 @Dao


### PR DESCRIPTION
I've finalized the application package name change from 'com.example.mymaterialapp' to 'com.mostree.memorycard'.

This involved:
- Updates to `applicationId` and `namespace` in `app/build.gradle`.
- Update to `package` attribute in `AndroidManifest.xml`.
- Renaming of the source code directory structure to `app/src/main/java/com/mostree/memorycard/`.
- Updates to `package` declarations in all Kotlin source files.
- Corrections to `import` statements in DAO files (`LearningCardDao.kt`, `LearningDeckDao.kt`) and `AppDatabase.kt` to correctly reference model classes under the new package structure.

These comprehensive changes resolve previous build failures related to `kaptDebugKotlin` tasks (e.g., `cannot find symbol`, `NonExistentClass` errors) and ensure the application correctly builds and references its components under the new package name `com.mostree.memorycard`.