### PR TITLE
Fix: Add step to accept Android SDK licenses in GitHub Actions workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
+      - name: Accept Android SDK licenses
+        run: yes | ${{ env.ANDROID_SDK_ROOT }}/cmdline-tools/latest/bin/sdkmanager --licenses || true
+
       - name: Grant execute permission to Gradle
         run: chmod +x ./gradlew
 


### PR DESCRIPTION
To resolve potential `ClassNotFoundException` caused by unaccepted SDK licenses leading to issues with `applicationId` recognition during the build process, this commit adds a step to automatically accept SDK licenses in the GitHub Actions workflow file (.github/workflows/android.yml).

The new step runs `yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --licenses || true` after setting up the Android SDK and before running Gradle tasks.